### PR TITLE
Fix for style attribute in markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,4 @@
-<style>
-    img.displayed {
-        display: block;
-        margin-left: auto;
-        margin-right: auto;
-        padding: 20px;
-    }
-</style>
-
-<img src="./icons/icon128.png" class="displayed">
+<img src="./icons/icon128.png" style="display: block; margin-left: auto; margin-right: auto; padding: 20px;">
 
 # Apollo Persisted Query Interceptor
 


### PR DESCRIPTION
The style attribute added to the README was not being honored in the markdown file. Using the style attribute on the `img` tag to resolve this.